### PR TITLE
Issues with migration to Spatie HTML fixed – fixes breaking changes.

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -10,11 +10,11 @@
     {!! html()->form('POST',route('auth.dologin'))->open() !!}
 
     <div>
-	{!! html()->label('username', 'Membership ID') !!}
+	{!! html()->label('Membership ID','username') !!}
 	{!! html()->text('username') !!}
     </div>
     <div>
-	{!! html()->label('password', 'Password') !!}
+	{!! html()->label('Password','password') !!}
 	{!! html()->password('password') !!}
     </div>
 
@@ -29,11 +29,11 @@
     {!! html()->form('POST', route('auth.dologin'))->open() !!}
 
     <div>
-	{!! html()->label('username', 'Membership ID') !!}
+	{!! html()->label('Membership ID','username') !!}
 	{!! html()->text('username') !!}
     </div>
     <div>
-	{!! html()->label('password', 'Last Name') !!}
+	{!! html()->label('Last Name','password') !!}
 	{!! html()->password('password') !!}
 	(exactly as in membership records, including punctuation and capitalisation)
     </div>

--- a/resources/views/auth/password.blade.php
+++ b/resources/views/auth/password.blade.php
@@ -1,18 +1,18 @@
 <x-layout>
     <x-slot:title>Change Password</x-slot:title>
 
-    {!! html()-form('POST',route('auth.password.update'))->open() !!}
+    {!! html()->form('POST',route('auth.password.update'))->open() !!}
 
     @if ($firsttime)
 	<p><strong>As this is the first time you have used this system, you must set a new password, and enter a verification code.</strong> The verification code has been sent to your preferred email address.</p>
 
 	<div>
-	    {!! html()->label('cpwd', 'Last Name') !!}
+	    {!! html()->label('Last Name', 'cpwd') !!}
 	    {!! html()->password('cpwd') !!} (again, exactly as recorded in membership data)
 	</div>
     @else
 	<div>
-	    {!! html()->label('cpwd', 'Current Password') !!}
+	    {!! html()->label('Current Password','cpwd') !!}
 	    {!! html()->password('cpwd') !!}
 	</div>
 
@@ -20,18 +20,18 @@
 
 
     <div>
-	{!! html()->label('npwd', 'New Password') !!}
+	{!! html()->label('New Password','npwd') !!}
 	{!! html()->password('npwd') !!}
     </div>
 
     <div>
-	{!! html()->label('npwd2', 'Confirm New Password') !!}
+	{!! html()->label('Confirm New Password','npwd2') !!}
 	{!! html()->password('npwd2') !!}
     </div>
 
     @if ($firsttime)
 	<div>
-	    {!! html()->label('code', 'Verification Code') !!}
+	    {!! html()->label('Verification Code', 'code') !!}
 	    {!! html()->text('code') !!}
 	    Check your email for this code - it will be eight letters and numbers
 	</div>

--- a/resources/views/auth/reset.blade.php
+++ b/resources/views/auth/reset.blade.php
@@ -1,7 +1,7 @@
 <x-layout>
     <x-slot:title>Reset Password</x-slot:title>
 
-    {!! html->form('POST','auth.doreset')->open() !!}
+    {!! html()->form()->method('POST')->action(route('auth.doreset'))->open() !!}
 
     <p>To reset your password, enter your membership ID, last name and preferred contact email <em>exactly</em> as in the membership records. If this is successful, you will then be able to log in again using your last name as the password and entering a code sent to your email address.</p>
 
@@ -10,15 +10,15 @@
     @endif
 
     <div>
-	{!! html()->label('username', 'Membership ID') !!}
+	{!! html()->label('Membership ID','username') !!}
 	{!! html()->text('username') !!}
     </div>
     <div>
-	{!! html()->label('lastname', 'Last Name') !!}
+	{!! html()->label('Last Name','lastname') !!}
 	{!! html()->password('lastname') !!}
     </div>
     <div>
-	{!! html()->label('email', 'Email') !!}
+	{!! html()->label('Email','email') !!}
 	{!! html()->password('email') !!}
     </div>
 

--- a/resources/views/ballots/form.blade.php
+++ b/resources/views/ballots/form.blade.php
@@ -17,24 +17,24 @@
 	<div><strong>Start: </strong> {{ $ballot->start->format("j F Y H:i") }}</div>
     @else
     <div>
-	{!! html()->label('title', 'Title') !!}
+	{!! html()->label('Title','title') !!}
 	{!! html()->text('title', $ballot->title) !!}
     </div>
     <div>
-	{!! html()->label('description', 'Description') !!}
+	{!! html()->label('Description','description') !!}
 	{!! html()->textarea('description', $ballot->description, ['class' => 'htmlbox']) !!} (HTML allowed)
     </div>
     <div>
-	{!! html()->label('votersonly', 'Voters Only?') !!}
+	{!! html()->label('Voters Only?','votersonly') !!}
 	{!! html()->checkbox('votersonly', 1, $ballot->votersonly) !!}
     </div>
     <div>
-	{!! html()->label('options', 'Options') !!}
+	{!! html()->label('Options','options') !!}
 	{!! html()->textarea('options', $ballot->options->pluck('option')->join("\n")) !!}
 	<br>(one per line, recommend two options + abstain)
     </div>
     <div>
-	{!! html()->label('start', 'Start') !!}
+	{!! html()->label('Start','start') !!}
 	{!! html()->datetime('start', ($ballot->start ? $ballot->start : \Carbon\Carbon::parse("+1 week"))->format("Y-m-d H:i:s")) !!}
     </div>
     @endif
@@ -42,7 +42,7 @@
 	<div><strong>End: </strong> {{ $ballot->end->format("j F Y H:i") }}</div>
     @else
 	<div>
-	    {!! html()->label('end', 'End') !!}
+	    {!! html()->label('End','end') !!}
 	    {!! html()->datetime('end', ($ballot->end ? $ballot->end : \Carbon\Carbon::parse("+2 weeks"))->format("Y-m-d H:i:s")) !!}
 	</div>
     @endif
@@ -65,7 +65,7 @@
 	{!! html()->form('DELETE', route('ballots.destroy', $ballot->id)) !!}
 	<p><strong>Warning:</strong> Ballot deletion cannot be undone.</p>
 	<div>
-	    {!! html()->label('confirm', 'Confirm by typing ballot title') !!}
+	    {!! html()->label('Confirm by typing ballot title','confirm') !!}
 	    {!! html()->text('confirm') !!}
 	</div>
 

--- a/resources/views/campaigns/bulkimport.blade.php
+++ b/resources/views/campaigns/bulkimport.blade.php
@@ -6,7 +6,7 @@
     <p>Import actions for {{ $campaign->name }}</p>
 
     <div>
-	{!! html()->label('action', 'Import as action') !!}
+	{!! html()->label('Import as action','action') !!}
 	{!! html()->select('action', [
 	    'yes' => 'Participated',
 	    'wait' => 'Intends to',
@@ -15,7 +15,7 @@
 	    ] ,'yes') !!}
     </div>
     <div>
-	{!! html()->label('members', 'Members') !!}
+	{!! html()->label('Members','members') !!}
 	{!! html()->textarea('members', '', ['rows'=>20]) !!}
 	<br>
 	One per line, using membership ID, email or phone

--- a/resources/views/campaigns/form.blade.php
+++ b/resources/views/campaigns/form.blade.php
@@ -8,32 +8,32 @@
     @endif
 
     <div>
-	{!! html()->label('name', 'Name') !!}
+	{!! html()->label('Name','name') !!}
 	{!! html()->text('name', $campaign->name) !!}
     </div>
     <div>
-	{!! html()->label('description', 'Description') !!}
+	{!! html()->label('Description','description') !!}
 	{!! html()->textarea('description', $campaign->description) !!}
     </div>
     <div>
-	{!! html()->label('type', 'Campaign Type') !!}
+	{!! html()->label('Campaign Type','type') !!}
 	{!! html()->select('type', App\Models\Campaign::campaignTypes(), $campaign->campaigntype) !!}
     </div>
 
     <div>
-	{!! html()->label('start', 'Start') !!}
+	{!! html()->label('Start','start') !!}
 	{!! html()->date('start', $campaign->start ? $campaign->start->format("Y-m-d") : "") !!}
     </div>
     <div>
-	{!! html()->label('end', 'End') !!}
+	{!! html()->label('End','end') !!}
 	{!! html()->date('end', $campaign->end ? $campaign->end->format("Y-m-d") : "") !!}
     </div>
     <div>
-	{!! html()->label('target', 'Target') !!}
-	{!! html()->number('target', $campaign->target, ['min'=>0, 'max'=>100]) !!}% ({{ $campaign->calctarget ?? "-" }})
+	{!! html()->label('Target','target') !!}
+    {!! html()->input('number', 'target')->value($campaign->target)->attributes(['min' => 0, 'max' => 100]) !!}% ({{ $campaign->calctarget ?? "-" }})
     </div>
     <div>
-	{!! html()->label('votersonly', 'Voters Only?') !!}
+	{!! html()->label('Voters Only?','votersonly') !!}
 	{!! html()->checkbox('votersonly', 1, $campaign->votersonly) !!}
     </div>
 
@@ -55,7 +55,7 @@
 	{!! html()->form('DELETE', route('campaigns.destroy', $campaign->id))->open() !!}
 	<p><strong>Warning:</strong> Campaign deletion cannot be undone.</p>
 	<div>
-	    {!! html()->label('confirm', 'Confirm by typing campaign name') !!}
+	    {!! html()->label('Confirm by typing campaign name','confirm') !!}
 	    {!! html()->text('confirm') !!}
 	</div>
 

--- a/resources/views/components/campaigns/statemenu.blade.php
+++ b/resources/views/components/campaigns/statemenu.blade.php
@@ -2,7 +2,7 @@
 
     @if ($campaign->campaigntype != App\Models\Campaign::CAMPAIGN_PETITION || $member->participation($campaign) != "yes")
 	<div>
-	    {!! html()->label('action'.$campaign->id, $campaign->name) !!}
+	    {!! html()->label($campaign->name,'action'.$campaign->id) !!}
 	    {!! html()->select('action'.$campaign->id, $campaign->stateDescriptions("They") ,$member->participation($campaign)) !!}
 	    @if ($campaign->campaigntype == App\Models\Campaign::CAMPAIGN_PETITION)
 		(you cannot record signatures on their behalf)

--- a/resources/views/import/index.blade.php
+++ b/resources/views/import/index.blade.php
@@ -1,10 +1,10 @@
 <x-layout>
     <x-slot:title>Import Membership List</x-slot:title>
 
-    {!! html()->form('POST', route('import.process', 'files' => true))->open() !!}
+    {!! html()->form('POST', route('import.process'))->attribute('enctype', 'multipart/form-data')->open() !!}
 
     <div>
-	{!! html()->label('list', 'Upload CSV membership list') !!}
+	{!! html()->label('Upload CSV membership list','list') !!}
 	{!! html()->file('list') !!}
     </div>
 

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -26,12 +26,12 @@
 	    <fieldset><legend>Select option</legend>
 	    <div>
 		{!! html()->radio('option', 0, true, ['id' => 'option_0']) !!}
-		{!! html()->label('option_0', '(select option)') !!}
+		{!! html()->label('(select option)','option_0') !!}
 	    </div>
 	    @foreach ($ballot->options()->orderBy('order')->get() as $option)
 		<div>
 		    {!! html()->radio('option', $option->id, false, ['id' => 'option_'.$option->id]) !!}
-		    {!! html()->label('option_'.$option->id, $option->option) !!}
+		    {!! html()->label($option->option,'option_'.$option->id) !!}
 		</div>
 	    @endforeach
 	    </fieldset><br>
@@ -57,7 +57,7 @@
 	    {!! html()->form('POST',route('participate', $campaign->id))->open() !!}
 
 	    <div>
-		{!! html()->label('participation'.$campaign->id, 'Have you participated?') !!}
+		{!! html()->label('Have you participated?','participation'.$campaign->id) !!}
 		{!! html()->select('participation'.$campaign->id, $campaign->stateDescriptions("I"), $self->participation($campaign)) !!}
 		{!! html()->submit("Update participation") !!}
 	    </div>

--- a/resources/views/members/edit.blade.php
+++ b/resources/views/members/edit.blade.php
@@ -23,7 +23,7 @@
     {!! html()->form('POST', route('members.updatenotes', $member->id))->open() !!}
 
     <div>
-	{!! html()->label('notes', 'Additional Notes') !!}
+	{!! html()->label('Additional Notes','notes') !!}
 	{!! html()->textarea('notes', $member->notes ) !!}
     </div>
 
@@ -41,7 +41,7 @@
 	@foreach ($workplaces as $workplace)
 	    <div>
 		{!! html()->checkbox('workplace'.$workplace->id, 1, $member->workplaces->where('id', $workplace->id)->count() > 0) !!}
-		{!! html()->label('workplace'.$workplace->id, $workplace->name) !!}
+		{!! html()->label($workplace->name,'workplace'.$workplace->id) !!}
 	    </div>
 	@endforeach
 	{!! html()->submit("Update workplaces") !!}
@@ -63,7 +63,7 @@
     <p>Remember to ask them to change their password to something only they know after they log in.</p>
 
     <div>
-	{!! html()->label('newpass', 'New temporary password') !!}
+	{!! html()->label('New temporary password','newpass') !!}
 	{!! html()->text('newpass') !!} (minimum 8 characters)
     </div>
 

--- a/resources/views/notices/form.blade.php
+++ b/resources/views/notices/form.blade.php
@@ -4,11 +4,11 @@
     @if ($notice->id)
 	{!! html()->form('PUT',route('notices.update', $notice->id))->open() !!}
     @else
-	{!! html()-form('POST',route('notices.store', 'method'))->open() !!}
+    {!! html()->form('POST', route('notices.store'))->open() !!}
     @endif
 
     <div>
-	{!! html()->label('meeting', 'Meeting') !!}
+	{!! html()->label('Meeting','meeting') !!}
 	{!! html()->text('meeting', $notice->meeting, ["list" => "meetings", "size" => 30]) !!} Leave blank if not associated with a meeting
 	<datalist id="meetings">
 	    @foreach ($meetings as $meeting)
@@ -17,29 +17,29 @@
 	</datalist>
     </div>
     <div>
-	{!! html()->label('title', 'Title') !!}
+	{!! html()->label('Title','title') !!}
 	{!! html()->text('title', $notice->title) !!}
     </div>
     <div>
-	{!! html()->label('content', 'Content') !!}
+	{!! html()->label('Content', 'content') !!}
 	{!! html()->textarea('content', $notice->content, ['class' => 'htmlbox']) !!}
 	(HTML markup allowed)
     </div>
     <div>
-	{!! html()->label('start', 'Start') !!}
+	{!! html()->label('Start', 'start') !!}
 	{!! html()->date('start', $notice->start ? $notice->start->format("Y-m-d") : "") !!}
 	({!! html()->label('nostart', 'no date?') !!}
 	{!! html()->checkbox('nostart', 1, $notice->start === null) !!})
 	Setting a start date a few weeks before the meeting date is strongly recommended for documents associated with meetings.
     </div>
     <div>
-	{!! html()->label('end', 'End') !!}
+	{!! html()->label('End', 'end') !!}
 	{!! html()->date('end', $notice->end ? $notice->end->format("Y-m-d") : "") !!}
 	({!! html()->label('noend', 'no date?') !!}
 	{!! html()->checkbox('noend', 1, $notice->end === null) !!})
     </div>
     <div>
-	{!! html()->label('highlight', 'Highlight on front page?') !!}
+	{!! html()->label('Highlight on front page?','highlight') !!}
 	{!! html()->checkbox('highlight', 1, $notice->highlight) !!}
     </div>
 

--- a/resources/views/roles/form.blade.php
+++ b/resources/views/roles/form.blade.php
@@ -8,19 +8,19 @@
     @endif
 
     <div>
-	{!! html()->label('member', 'Member ID') !!}
+	{!! html()->label('Member ID','member') !!}
 	{!! html()->text('member', $role->member ? $role->member->membership : "") !!}
     </div>
     <div>
-	{!! html()->label('role', 'Role') !!}
+	{!! html()->label('Role','role') !!}
 	{!! html()->select('role', $types, $role->role) !!}
     </div>
     <div>
-	{!! html()->label('restrictfield', 'Restrict Field') !!}
+	{!! html()->label('Restrict Field','restrictfield') !!}
 	{!! html()->select('restrictfield', $fields, $role->restrictfield) !!}
     </div>
     <div>
-	{!! html()->label('restrictvalue', 'Restrict Value') !!}
+	{!! html()->label('Restrict Value','restrictvalue') !!}
 	{!! html()->text('restrictvalue', $role->restrictvalue) !!}
     </div>
 

--- a/resources/views/workplace/form.blade.php
+++ b/resources/views/workplace/form.blade.php
@@ -8,11 +8,11 @@
     @endif
 
     <div>
-	{!! html()->label('name', 'Name') !!}
+	{!! html()->label( 'Name','name') !!}
 	{!! html()->text('name', $workplace->name) !!} (must be unique)
     </div>
     <div>
-	{!! html()->label('newmembers', 'Import Members') !!}
+	{!! html()->label('Import Members','newmembers') !!}
 	{!! html()->textarea('newmembers', '') !!} (member id, email or phone; one per line)
     </div>
 
@@ -21,7 +21,7 @@
 	    @foreach ($workplace->members()->orderBy('lastname')->get() as $member)
 		<div>
 		    {!! html()->checkbox('detach[]', $member->id, false, ['id' => 'detach_'.$member->id]) !!}
-		    {!! html()->label('detach_'.$member->id, $member->membership.": ".$member->firstname." ".$member->lastname." (".$member->department.")") !!}
+		    {!! html()->label($member->membership.": ".$member->firstname." ".$member->lastname." (".$member->department.")",'detach_'.$member->id) !!}
 		</div>
 	    @endforeach
 	</fieldset>
@@ -36,7 +36,7 @@
 	{!! html()->form('DELETE',route('workplaces.destroy', $workplace->id))->open() !!}
 	<p><strong>Warning:</strong> Workplace deletion cannot be undone.</p>
 	<div>
-	    {!! html()->label('confirm', 'Confirm by typing workplace name') !!}
+	    {!! html()->label('Confirm by typing workplace name','confirm') !!}
 	    {!! html()->text('confirm') !!}
 	</div>
 


### PR DESCRIPTION
These bugs are related to the migration to Spatie HTML as part of the migration. One set reflects that the order of parameters, for some reason, has changed, such that the label text itself now needs to be the first and then the ID second. The bug was visible in pages with form labels; the label text became the ID and then the labels were "for" the text – of course there are no elements with those names! 

There are other adjustments too – in some places a typo, in other places I had made more assumptions about the compatibility of the old and the new HTML libraries. So there were quite a few dead links etc – so my earlier changes were, with apologies, breaking ones. I've done a whole bunch of digging and I *think* I've found them all; with apologies if I need to make more PRs... 