### PR TITLE
Fixing bug with role creation

### DIFF
--- a/resources/views/roles/form.blade.php
+++ b/resources/views/roles/form.blade.php
@@ -4,7 +4,7 @@
     @if ($role->id)
 	{!! html()->form('PUT',route('roles.update', $role->id))->open() !!}
     @else
-	{!! html()->form('POST',route('roles.store')) !!}
+	{!! html()->form('POST',route('roles.store'))->open() !!}
     @endif
 
     <div>


### PR DESCRIPTION
It wasn't possible to create new roles because the <form> tag was not opened. This meant that the <form> element had no children and consequently clicking the edit button didn't do anything when creating a new role. (Editing existing ones worked fine – line 5). Apologies, another issue related to conversion to Laravel 11 and the Spatie HTML package.