### PR TITLE
Fixing checkbox issues

### DIFF
--- a/app/Http/Controllers/CampaignController.php
+++ b/app/Http/Controllers/CampaignController.php
@@ -84,7 +84,7 @@ class CampaignController extends Controller
         $campaign->start = Carbon::parse($request->input('start'));
         $campaign->end = Carbon::parse($request->input('end'));
         $campaign->target = $request->input('target');
-        $campaign->votersonly = $request->input('votersonly', false);
+        $campaign->votersonly = $request->boolean('votersonly');
         if ($campaign->end->isFuture()) {
             if ($campaign->votersonly) {
                 $count = Member::where('voter', true)->count();

--- a/resources/views/members/edit.blade.php
+++ b/resources/views/members/edit.blade.php
@@ -40,8 +40,8 @@
 	{!! html()->form('POST',route('members.updateworkplace', $member->id))->open() !!}
 	@foreach ($workplaces as $workplace)
 	    <div>
-		{!! html()->checkbox('workplace'.$workplace->id, 1, $member->workplaces->where('id', $workplace->id)->count() > 0) !!}
-		{!! html()->label($workplace->name,'workplace'.$workplace->id) !!}
+        {!! html()->checkbox('workplace'.$workplace->id, 1)->checked(in_array($workplace->id, $member->workplaces->pluck('id')->toArray())) !!}
+        {!! html()->label($workplace->name,'workplace'.$workplace->id) !!}
 	    </div>
 	@endforeach
 	{!! html()->submit("Update workplaces") !!}


### PR DESCRIPTION
Two more bugs! 

The change in `CampaignController.php` is necessary because getting `votersonly` can return `1`. From my testing, SQLite is fine with this and will convert it to a `1`, but MariaDB rejects it, saying that it's expecting an `int`. Getting the `boolean` seems more reliable accross the DBs here.

The change in `edit.blade.php` was to do with the checkboxes for workplace. The old code, which I introduced as part of the Laravel 11 conversion, made every checkbox checked... even if the underlying data should've produced an unchecked state. This is now fixed. Apologies again for yet another conversion bug.